### PR TITLE
fix(setup): Fix error when no configuration scriptlets are installed.

### DIFF
--- a/setup.sh.source
+++ b/setup.sh.source
@@ -10,6 +10,13 @@ if [ -v _BASH_RC_D_SETUPPED ]; then
     return 0
 fi
 
+if ! shopt -s nullglob; then
+    printf \
+        'Error: Unable to set the "nullglob" shell option.\n' \
+        1>&2
+    return 1
+fi
+
 for source_file in "$HOME"/.bashrc.d/*.source.bash; do
     source "${source_file}"
 done


### PR DESCRIPTION
Filename expansion will return matching pattern when no files are matched.  This patch sets the "nullglob" shell option to avoid this behavior.

Fixes #8.